### PR TITLE
Add git ignore for build dir and common generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+*~
+*.pyc
+*.pyo


### PR DESCRIPTION
When installing via PyBOMBS the build directory is put at the top of the tree; this ignore file will prevent that from showing up as a modification.  Also includes a few other stray files that often get generated.
