### PR TITLE
Fix some assertions that are working the opposite way.

### DIFF
--- a/lib/inner_coder_impl.cc
+++ b/lib/inner_coder_impl.cc
@@ -165,14 +165,14 @@ namespace gr {
       // We output one byte for a symbol of m bits
       // The out/in rate in bytes is: 8n/km (Bytes)
 
-      assert(d_ninput % 1);
-      assert(d_noutput % 1512);
+      assert(d_ninput % 1 == 0);
+      assert(d_noutput % 1512 == 0);
 
       // Set output items multiple of 4
       set_output_multiple(4);
 
       // Set relative rate out/in
-      assert((d_noutput * d_k * d_m) % (d_ninput * 8 * d_n));
+      assert((d_noutput * d_k * d_m) % (d_ninput * 8 * d_n) == 0);
       set_relative_rate((float)(d_ninput * 8 * d_n) / (float)d_noutput * d_k * d_m);
 
       // calculate in and out block sizes


### PR DESCRIPTION
There are some assertions in the code that are probably written the opposite way around. This patch fixes them (note, in particular, that line 168 is bound to be always false in its original form).

With this patch I'm able to correctly run https://github.com/argilo/sdr-examples/blob/master/dvbt-hackrf.py (without the assertions fail).